### PR TITLE
Executing `@echo off` in .bat files

### DIFF
--- a/bco2obj.bat
+++ b/bco2obj.bat
@@ -1,2 +1,3 @@
+@echo off
 python "%~dp0mkdd-collision-reader.py" %1
 pause

--- a/obj2bco.bat
+++ b/obj2bco.bat
@@ -1,2 +1,3 @@
+@echo off
 python "%~dp0mkdd-collision-creator.py" %*
 pause


### PR DESCRIPTION
Executing this command will make it so that future code lines in the file won't be printed into the console window. This helps overall to make the screen less cluttered.