### PR TITLE
Correction for material names

### DIFF
--- a/mkdd-collision-reader.py
+++ b/mkdd-collision-reader.py
@@ -138,8 +138,8 @@ class RacetrackCollision(object):
         self.matentries = []
 
         for i in range(self.entrycount):
-            val1, val2, unk, int1, int2 = unpack_from(">BBHII", f.read(0xC), 0)
-            self.matentries.append((val1, val2, unk, int1, int2))
+            floor_type, unk, int1, int2 = unpack_from(">HHII", f.read(0xC), 0)
+            self.matentries.append((floor_type, unk, int1, int2))
 
 
 
@@ -199,23 +199,18 @@ def create_col(f, soundfile, mkdd_collision):
             #if True:
             #print(i, hex(floor_type),unk1+1,unk2+1,unk3+1, len(mkdd_collision.triangles))
             #fasd.write("{0} {1} {2} {3} {4} {5} {6}\n".format(i, hex(floor_type),unk1+1,unk2+1,unk3+1, len(mkdd_collision.triangles), (v1,v2,v3)))
-            if lasttype != floor_type:
-                if floor_type not in floortypes:
-                    for entry in mkdd_collision.matentries:
-                        if floor_type>>8 == entry[0] and floor_type & 0xFF == entry[1]:
-                            floortypes[floor_type] = entry[2:]
-
+            currenttype = (tri.floor_type, tri.unknown, tri.unknown2)
+            if currenttype != lasttype:
                 f.write("usemtl Roadtype_0x{0:04X}_0x{1:02X}_0x{2:08X}\n".format(floor_type, tri.unknown, tri.unknown2))
-                lasttype = floor_type
+                lasttype = currenttype
 
             f.write("f {0} {1} {2}\n".format(tri.v1+1,tri.v2+1,tri.v3+1))
             i += 1
-    
-    for floortype in sorted(floortypes.keys()):
-        matdata = floortypes[floortype]
-        
-        soundfile.write("0x{:04X}=0x{:X}, 0x{:X}, 0x{:X}\n".format(floortype, *matdata))
-            
+
+    for entry in mkdd_collision.matentries:
+        soundfile.write("0x{:04X}=0x{:X}, 0x{:X}, 0x{:X}\n".format(*entry))
+
+
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser()

--- a/mkdd-collision-reader.py
+++ b/mkdd-collision-reader.py
@@ -205,7 +205,7 @@ def create_col(f, soundfile, mkdd_collision):
                         if floor_type>>8 == entry[0] and floor_type & 0xFF == entry[1]:
                             floortypes[floor_type] = entry[2:]
 
-                f.write("usemtl Roadtype_0x{0:04X}_0x{2:08X}\n".format(floor_type, tri.unknown, tri.unknown2))
+                f.write("usemtl Roadtype_0x{0:04X}_0x{1:02X}_0x{2:08X}\n".format(floor_type, tri.unknown, tri.unknown2))
                 lasttype = floor_type
 
             f.write("f {0} {1} {2}\n".format(tri.v1+1,tri.v2+1,tri.v3+1))


### PR DESCRIPTION
Two issues have been addressed:

**Issue 1**

The lone byte in the triangle structure (offset `0x19`) was _not_ preserved in the OBJ file. The information was lost forever. Now the byte is stored in the material name, which is then restored when the OBJ file is converted to BCO.

Previously:
```
Roadtype_0x0100_0x00000000
```

Now:
```
Roadtype_0x0100_0x01_0x00000000
```

This byte seems to determine the position of the third-person camera view. `0x01` is the most common value. `0x02` is used to make the camera lower (closer to the exhaust pipe), giving the impression of an "intense mode". Other values seen in the stock courses are `0x00`, and `0x05`, but their meaning is not clear yet.

**Issue 2**

Materials in the OBJ file could be wrongly over-reused for triangles that were meant to have a different material assigned. The [partially] unknown bytes in the triangle structure (offsets `0x19`, and `0x20`, `0x21`, `0x22` and `0x23`) were not taken into account for determining when a new material had to be defined; triangles that had a different byte structure could be assigned a wrong material if their terrain type solely matched the terrain type of the previous triangle.

Previously:
```
Roadtype_0x0100_0x01_0x00000100
f 5 12 45
f 4 9 1
f 6 2 41
```
Now:
```
Roadtype_0x0100_0x01_0x00000100
f 5 12 45
f 4 9 1
Roadtype_0x0100_0x01_0x00000000
f 6 2 41
```

These bytes are mostly unknown. One of them (offset `0x22`) is typically seen in dead zones, and indicates whether karts flying over these triangles need to play the falling animation. Having the byte mistakenly borrowed from other triangles meant that the falling animation would be played almost in every legitimate jump.